### PR TITLE
PT172-116: Configurar los log para el grupo de datos A

### DIFF
--- a/bigdata/dataGroupA/logging.cfg
+++ b/bigdata/dataGroupA/logging.cfg
@@ -1,0 +1,29 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=hand_console_grupo_a, hand_file_grupo_a
+
+[formatters]
+keys=formatter_log
+
+[logger_root]
+level=DEBUG
+handlers=hand_console_grupo_a, hand_file_grupo_a
+
+[handler_hand_console_grupo_a]
+class=StreamHandler
+level=DEBUG
+formatter=formatter_log
+args=(sys.stdout,)
+
+[handler_hand_file_grupo_a]
+class=handlers.TimedRotatingFileHandler
+level=DEBUG
+formatter=formatter_log
+args=('../logging/log_grupo_A.log','W0')
+
+[formatter_formatter_log]
+format=%(asctime)s %(levelname)s %(message)s
+datefmt=%d-%b-%Y
+class=logging.Formatter 

--- a/bigdata/dataGroupA/top10tags.py
+++ b/bigdata/dataGroupA/top10tags.py
@@ -2,9 +2,15 @@ from decouple import config
 from collections import Counter
 from functools import reduce
 import xml.etree.ElementTree as ET
+import logging
+import logging.config
 import re
 import pathlib
+import sys
 
+
+logging.config.fileConfig(f'{pathlib.Path(__file__).parent.absolute()}/logging.cfg')
+logger = logging.getLogger('top_10_tags_A')
 
 def divide_chunks(iterable, n):
     for i in range(0, len(iterable), n):
@@ -50,11 +56,21 @@ def reducer_CounterTags(dicc1, dicc2):
 
 
 if '__main__' == __name__:
-    path = str(pathlib.Path().absolute()) + '/../..' + \
-        config('dataset_path') + 'posts.xml'
-    tree_xml = ET.parse(path)
+    try:
+        path = str(pathlib.Path().absolute()) + '/../..' + \
+            config('dataset_path') + 'posts.xml'
+        tree_xml = ET.parse(path)
+    except FileNotFoundError as e:
+        logger.error(f"top10tags - Archivo de datos no encontrado en la ruta: {e}")
+        sys.exit(1)
+    except ET.ParseError as e:
+        logger.error(f"top10tags - Error al parsear el archivo: {path}")
+        logger.error(e.msg)
+        sys.exit(1)
     data_chunks = divide_chunks(tree_xml.getroot(), 100)
+    logger.info(f'top10tags - Division de datos en chunks del archivo {path}')
 
+    logger.info('top10tags - Inicio del procesamiento')
     # llamada a la funcion mapper principal
     mapped = list(map(mapper, data_chunks))
     # llamada a la funcion reduce principal
@@ -62,10 +78,15 @@ if '__main__' == __name__:
     # ordenar los valores, obviamente no en diccionarios
     mapped = sorted(mapped.items(), key=lambda x: x[1], reverse=True)[:10]
 
+    logger.info('top10tags - Fin del procesamiento')
     path_download = str(pathlib.Path().absolute()) + \
         '/../..' + config('files_path') + 'top10tagsA.txt'
-    with open(path_download, 'w') as f:
-        for i in range(len(mapped)):
-            f.write(str(i + 1) + ': ' +
-                    mapped[i][0] + ' ' + str(mapped[i][1]) + '\n')
-    print('Done!')
+    try:
+        with open(path_download, 'w') as f:
+            for i in range(len(mapped)):
+                f.write(str(i + 1) + ': ' +
+                        mapped[i][0] + ' ' + str(mapped[i][1]) + '\n')
+    except Exception as e:
+        logger.error(f'top10tags - Error al escribir archivo: {path_download}, fin del programa')
+        sys.exit(1)
+    logger.info(f'top10tags - Archivo de salida: {path_download}')


### PR DESCRIPTION
COMO: Analista de datos
QUIERO: Configurar los log
PARA: Mostrarlos en consola

Criterios de aceptación: 

    Utilizar Libreria Loging.

    Loguear en 2 hilos por consola y por fichero rotativo cada 7 dias.

    Consola:  %d-%m-%Y_levelname_name_message

    Fichero: %d-%m-%Y_levelname_name_message

    La configuración debe estar en un archivo .cfg